### PR TITLE
Upgraded d3 from v4 to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # d3-timeline
 
-A d3 v4 version of d3-timeline 
+A d3 v5 version of d3-timeline 
 
 Get something that looks like
 
@@ -209,7 +209,7 @@ sets the placement of the axis. Defaults to bottom.
 
 ### .colors(callback)
 
-sets the d3 color scale the data series in the timeline. Defaults to `d3.scale.category20()`.
+sets the d3 color scale the data series in the timeline. Defaults to `d3-scale-chromatic.schemeSet3()`.
 
 ### .colorProperty(propertyName)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "d3-timelines",
-	"version": "1.3.1",
-	"description": "A d3 v4 version of timeline. Can display single bar timelines, timelines with icons, and timelines that pan.",
+	"version": "1.4.1",
+	"description": "A d3 v5 version of timeline. Can display single bar timelines, timelines with icons, and timelines that pan.",
 	"keywords": [
 		"d3",
 		"d3-module",
@@ -18,33 +18,34 @@
 	"scripts": {
 		"pretest": "rm -rf build && mkdir build && rollup -c -f umd -n d3 -o build/d3-timelines.js -- index.js",
 		"test": "tape 'test/**/*-test.js'",
-		"prepare": "npm run test && uglifyjs build/d3-timelines.js -c -m -o build/d3-timelines.min.js",
+		"prepare": "npm run test && terser build/d3-timelines.js -c -m -o build/d3-timelines.min.js",
 		"postpublish": "zip -j build/d3-timelines.zip -- LICENSE README.md build/d3-timelines.js build/d3-timelines.min.js"
 	},
 	"peerDependencies": {
-		"d3-array": "^1.2.0",
-		"d3-axis": "^1.0.7",
-		"d3-scale": "^1.0.6",
-		"d3-selection": "^1.1.0",
-		"d3-time": "^1.0.6",
-		"d3-time-format": "^2.0.5",
-		"d3-zoom": "^1.2.0"
+		"d3-array": "^1.2.1",
+		"d3-axis": "^1.0.8",
+		"d3-scale": "^2.0.0",
+		"d3-selection": "^1.3.0",
+		"d3-time": "^1.0.8",
+		"d3-time-format": "^2.1.1",
+		"d3-zoom": "^1.7.1"
 	},
 	"devDependencies": {
-		"@types/d3": "^4.5",
+		"@types/d3": "5",
 		"rollup": "0.27",
 		"rollup-plugin-node-resolve": "^3.0.0",
 		"tape": "4",
-		"uglify-js": "2"
+		"terser": "^5.39.1"
 	},
 	"dependencies": {
-		"d3": "^4.9.1",
-		"d3-array": "^1.2.0",
-		"d3-axis": "^1.0.7",
-		"d3-scale": "^1.0.6",
-		"d3-selection": "^1.1.0",
-		"d3-time": "^1.0.6",
-		"d3-time-format": "^2.0.5",
-		"d3-zoom": "^1.2.0"
+		"d3": "^5.16.0",
+		"d3-array": "^1.2.1",
+		"d3-axis": "^1.0.8",
+		"d3-scale": "^2.0.0",
+		"d3-scale-chromatic": "^3.1.0",
+		"d3-selection": "^1.3.0",
+		"d3-time": "^1.0.8",
+		"d3-time-format": "^2.1.1",
+		"d3-zoom": "^1.7.1"
 	}
 }

--- a/src/timelines.js
+++ b/src/timelines.js
@@ -3,9 +3,10 @@ import { axisBottom, axisTop } from 'd3-axis';
 import { range } from 'd3-array';
 import { timeFormat } from 'd3-time-format';
 import { timeHour } from 'd3-time';
-import { scaleOrdinal, scaleTime, scaleLinear, schemeCategory20 } from 'd3-scale';
+import { scaleOrdinal, scaleTime, scaleLinear } from 'd3-scale';
 import { event, mouse, namespace, namespaces, select } from 'd3-selection';
 import { zoom as d3z } from 'd3-zoom'
+import { schemeSet3 } from 'd3-scale-chromatic';
 
 var timelines = function() {
 		var DISPLAY_TYPES = ["circle", "rect"];
@@ -34,7 +35,7 @@ var timelines = function() {
 				allowZoom = true,
 				axisBgColor = "white",
 				chartData = {},
-				colorCycle = scaleOrdinal(schemeCategory20),
+				colorCycle = scaleOrdinal(schemeSet3),
 				colorPropertyName = null,
 				display = "rect",
 				beginning = 0,


### PR DESCRIPTION
# 🚀 Minor Release: Upgrade to D3 v5

We’ve upgraded **d3-timelines** from **D3 v4** to **D3 v5** to ensure compatibility with modern D3 tooling and improve long-term maintainability.

## 📦 What’s Changed

- 🔄 **Upgraded D3 core from v4 to v5**
- ✅ Replaced all deprecated or changed D3 APIs:
  - `d3.schemeCategory20` → manually defined equivalent array or `d3-scale-chromatic` fallback
- ✅ Replaced uglify-js with terser.

## 🧠 Migration Notes

If you are using `d3-timelines` in a project that still depends on **D3 v4**, you have a few options:

- Stick with the previous version of `d3-timelines`
- Upgrade your D3 dependency to v5:
  ```bash
  yarn add d3@^5
  # or
  npm install d3@^5
